### PR TITLE
Update bela-setup-monome.sh

### DIFF
--- a/bela-setup-monome.sh
+++ b/bela-setup-monome.sh
@@ -28,7 +28,7 @@ cat << EOF > serialoscd.service
 Description=serialosc daemon
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/serialoscd
+ExecStart=/usr/local/bin/serialoscd -c ~/.config/serialosc/
 PIDFile=/var/run/serialoscd.pid
 RemainAfterExit=no
 Restart=on-failure


### PR DESCRIPTION
This update makes sure the serialoscd uses the config file in the default folder defined by this argument. This prevents serialoscd from using a different port each time it starts. The instructions for generating the config file are here: https://monome.org/docs/serialosc/linux/#notes